### PR TITLE
Specify the ApplicationController in all the Passkit controllers

### DIFF
--- a/app/controllers/passkit/dashboard/logs_controller.rb
+++ b/app/controllers/passkit/dashboard/logs_controller.rb
@@ -1,6 +1,6 @@
 module Passkit
   module Dashboard
-    class LogsController < ApplicationController
+    class LogsController < Passkit::Dashboard::ApplicationController
       def index
         @logs = Passkit::Log.order(created_at: :desc).first(100)
       end

--- a/app/controllers/passkit/dashboard/passes_controller.rb
+++ b/app/controllers/passkit/dashboard/passes_controller.rb
@@ -1,6 +1,6 @@
 module Passkit
   module Dashboard
-    class PassesController < ApplicationController
+    class PassesController < Passkit::Dashboard::ApplicationController
       def index
         @passes = Passkit::Pass.order(created_at: :desc).includes(:devices).first(100)
       end

--- a/app/controllers/passkit/dashboard/previews_controller.rb
+++ b/app/controllers/passkit/dashboard/previews_controller.rb
@@ -1,6 +1,6 @@
 module Passkit
   module Dashboard
-    class PreviewsController < ApplicationController
+    class PreviewsController < Passkit::Dashboard::ApplicationController
       def index
       end
 


### PR DESCRIPTION
This gem was trying to use the WCS `ApplicationController` instead of the Passkit `ApplicationController`, so fixed it in the gem code locally, but as a more permanent fix, I wanted to change this in a fork of the repo.