### PR TITLE
Allow additional params to be passed to the wallet passes

### DIFF
--- a/app/controllers/passkit/api/v1/passes_controller.rb
+++ b/app/controllers/passkit/api/v1/passes_controller.rb
@@ -50,7 +50,13 @@ module Passkit
             generator_class = payload[:generator_class].constantize
             generator = generator_class.find(payload[:generator_id])
           end
-          Passkit::Factory.create_pass(payload[:pass_class], generator)
+
+          additional_params = {}
+          if payload[:additional_params].present?
+            additional_params = payload[:additional_params].to_h
+          end
+
+          Passkit::Factory.create_pass(payload[:pass_class], generator, additional_params)
         end
       end
     end

--- a/app/controllers/passkit/dashboard/previews_controller.rb
+++ b/app/controllers/passkit/dashboard/previews_controller.rb
@@ -6,7 +6,13 @@ module Passkit
 
       def show
         builder = Passkit.configuration.available_passes[params[:class_name]]
-        path = Factory.create_pass(params[:class_name].constantize, builder.call)
+        if Passkit.configuration.additional_params.has_key?(params[:class_name])
+          additional_params = Passkit.configuration.additional_params[params[:class_name]]
+        else
+          additional_params = {}
+        end
+
+        path = Factory.create_pass(params[:class_name].constantize, builder.call, additional_params)
 
         send_file path, type: "application/vnd.apple.pkpass", disposition: "attachment", filename: "pass.pkpass"
       end

--- a/app/models/passkit/pass.rb
+++ b/app/models/passkit/pass.rb
@@ -42,7 +42,7 @@ module Passkit
     end
 
     def instance
-      @instance ||= klass.constantize.new(generator)
+      @instance ||= klass.constantize.new(generator, additional_params)
     end
 
     def last_update

--- a/lib/generators/templates/create_passkit_tables.rb.tt
+++ b/lib/generators/templates/create_passkit_tables.rb.tt
@@ -7,6 +7,7 @@ class CreatePasskitTables < ActiveRecord::Migration[<%= ActiveRecord::Migration.
       t.string :serial_number
       t.string :authentication_token
       t.json :data
+      t.json :additional_params
       t.integer :version
       t.timestamps null: false
       t.index [:generator_type, :generator_id], name: 'index_passkit_passes_on_generator'

--- a/lib/generators/templates/passkit.rb
+++ b/lib/generators/templates/passkit.rb
@@ -1,3 +1,4 @@
 Passkit.configure do |config|
   # config.available_passes['Passkit::YourPass'] = -> { User.create }
+  # config.additional_params['Passkit::YourPass'] = {"param_key" => "param_value"}
 end

--- a/lib/passkit.rb
+++ b/lib/passkit.rb
@@ -22,6 +22,7 @@ module Passkit
 
   class Configuration
     attr_accessor :available_passes,
+      :additional_params,
       :web_service_host,
       :certificate_key,
       :private_p12_certificate,
@@ -41,6 +42,7 @@ module Passkit
 
     def initialize
       @available_passes = {"Passkit::ExampleStoreCard" => -> {}}
+      @additional_params = {}
       @web_service_host = ENV["PASSKIT_WEB_SERVICE_HOST"] || (raise "Please set PASSKIT_WEB_SERVICE_HOST")
       raise("PASSKIT_WEB_SERVICE_HOST must start with https://") unless @web_service_host.start_with?("https://")
       @certificate_key = ENV["PASSKIT_CERTIFICATE_KEY"] || (raise "Please set PASSKIT_CERTIFICATE_KEY")

--- a/lib/passkit/base_pass.rb
+++ b/lib/passkit/base_pass.rb
@@ -1,7 +1,8 @@
 module Passkit
   class BasePass
-    def initialize(generator = nil)
+    def initialize(generator = nil, additional_params = {})
       @generator = generator
+      @additional_params = additional_params
     end
 
     def format_version

--- a/lib/passkit/factory.rb
+++ b/lib/passkit/factory.rb
@@ -1,8 +1,8 @@
 module Passkit
   class Factory
     class << self
-      def create_pass(pass_class, generator = nil)
-        pass = Passkit::Pass.create!(klass: pass_class, generator: generator)
+      def create_pass(pass_class, generator = nil, additional_params = {})
+        pass = Passkit::Pass.create!(klass: pass_class, generator: generator, additional_params: additional_params)
         Passkit::Generator.new(pass).generate_and_sign
       end
     end

--- a/lib/passkit/payload_generator.rb
+++ b/lib/passkit/payload_generator.rb
@@ -2,17 +2,18 @@ module Passkit
   class PayloadGenerator
     VALIDITY = 30.days
 
-    def self.encrypted(pass_class, generator = nil)
-      UrlEncrypt.encrypt(hash(pass_class, generator))
+    def self.encrypted(pass_class, generator = nil, additional_params = {})
+      UrlEncrypt.encrypt(hash(pass_class, generator, additional_params))
     end
 
-    def self.hash(pass_class, generator = nil)
+    def self.hash(pass_class, generator = nil, additional_params = {})
       valid_until = VALIDITY.from_now
 
       {valid_until: valid_until,
        generator_class: generator&.class&.name,
        generator_id: generator&.id,
-       pass_class: pass_class.name}
+       pass_class: pass_class.name,
+       additional_params: additional_params}
     end
   end
 end

--- a/lib/passkit/url_generator.rb
+++ b/lib/passkit/url_generator.rb
@@ -2,9 +2,9 @@ module Passkit
   class UrlGenerator
     include Passkit::Engine.routes.url_helpers
 
-    def initialize(pass_class, generator = nil)
+    def initialize(pass_class, generator = nil, additional_params = {})
       @url = passes_api_url(host: ENV["PASSKIT_WEB_SERVICE_HOST"],
-        payload: PayloadGenerator.encrypted(pass_class, generator))
+        payload: PayloadGenerator.encrypted(pass_class, generator, additional_params))
     end
 
     def ios


### PR DESCRIPTION
Add additional params to fields passed to the Apple Wallet pass so I can pass fields from an object not stored in the same database.