### PR TITLE
[#6422] Give tmp/passkit write permissions so it can be deleted by cron job

### DIFF
--- a/lib/passkit/generator.rb
+++ b/lib/passkit/generator.rb
@@ -30,7 +30,7 @@ module Passkit
     end
 
     def create_temporary_directory
-      FileUtils.mkdir_p(TMP_FOLDER) unless File.directory?(TMP_FOLDER)
+      FileUtils.mkdir_p(TMP_FOLDER, mode: 0775) unless File.directory?(TMP_FOLDER) # standard:disable Style/NumericLiteralPrefix
       @temporary_path = TMP_FOLDER.join(@pass.file_name.to_s)
 
       FileUtils.rm_rf(@temporary_path) if File.directory?(@temporary_path)
@@ -38,6 +38,7 @@ module Passkit
 
     def copy_pass_to_tmp_location
       FileUtils.cp_r(@pass.pass_path, @temporary_path)
+      FileUtils.chmod(0775, @temporary_path) # standard:disable Style/NumericLiteralPrefix
     end
 
     def clean_ds_store_files


### PR DESCRIPTION
[#6422](https://github.com/wildlife-conservation-society/wcs/issues/6422)

- When creating `tmp/passkit`, use permissions `0775`, so the group has write permissions and the contents of the directory can be deleted.
- After copying the pass's contents into the pass specific directory, chmod it with `0775` so the group has write permissions and the content of the directory can be deleted.