### PR TITLE
[#6087] Fix issue with new versions of OpenSSL not able to read p12 files

### DIFF
--- a/app/controllers/passkit/api/v1/logs_controller.rb
+++ b/app/controllers/passkit/api/v1/logs_controller.rb
@@ -5,8 +5,20 @@ module Passkit
         def create
           params[:logs].each do |message|
             Log.create!(content: message)
+
+            log(message)
           end
           render json: {}, status: :ok
+        end
+
+        private
+
+        def log(msg)
+          apple_wallet_log.info(msg)
+        end
+
+        def apple_wallet_log
+          @order_processor_log ||= Logger.new("log/#{Rails.env}_apple_wallet_log.log")
         end
       end
     end

--- a/lib/passkit/generator.rb
+++ b/lib/passkit/generator.rb
@@ -96,6 +96,9 @@ module Passkit
 
     # :nocov:
     def sign_manifest
+      OpenSSL::Provider.load("default")
+      OpenSSL::Provider.load("legacy")
+
       p12_certificate = OpenSSL::PKCS12.new(File.read(CERTIFICATE), CERTIFICATE_PASSWORD)
       intermediate_certificate = OpenSSL::X509::Certificate.new(File.read(INTERMEDIATE_CERTIFICATE))
 


### PR DESCRIPTION
[#6087](https://github.com/wildlife-conservation-society/wcs/issues/6087)

- Have `OpenSSL` look at the default and legacy providers such that our p12 files we use for Apple Wallet still work.