### PR TITLE
[#6580] Add actual log to Passkit's database logging system

### DIFF
--- a/app/controllers/passkit/api/v1/logs_controller.rb
+++ b/app/controllers/passkit/api/v1/logs_controller.rb
@@ -5,8 +5,20 @@ module Passkit
         def create
           params[:logs].each do |message|
             Log.create!(content: message)
+
+            log(message)
           end
           render json: {}, status: :ok
+        end
+
+        private
+
+        def log(msg)
+          apple_wallet_log.info(msg)
+        end
+
+        def apple_wallet_log
+          @order_processor_log ||= Logger.new("log/#{Rails.env}_apple_wallet_log.log")
         end
       end
     end


### PR DESCRIPTION
[#6580](https://github.com/wildlife-conservation-society/wcs/issues/6580)

- Create new log for Apple Wallet.
- Anytime a new log is created for the database, add it to the new Apple Wallet log as well.